### PR TITLE
Fix "variable 'Type' shadowed in 'fun'" warning.

### DIFF
--- a/src/sheriff.erl
+++ b/src/sheriff.erl
@@ -70,11 +70,9 @@ gen_check_funcs([], Module, Acc) ->
 			{'$var', Module}:TypeFunc(Val);
 		(Val, Type) when is_list(Type) ->
 			{ModulePart, TypePart} = try
-				fun(Type) ->
-					[ModulePart, TypePart] = string:tokens(Type, ":"),
-					[TypeString, ")"] = string:tokens(TypePart, "("),
-					{ModulePart, TypeString}
-				end(Type)
+				[ModulePart2, TypePart2] = string:tokens(Type, ":"),
+				[TypePart3, ")"] = string:tokens(TypePart2, "("),
+				{ModulePart2, TypePart3}
 			catch error:{badmatch, _} ->
 				error(badarg)
 			end,


### PR DESCRIPTION
Rewrite a block that was causing a "variable 'Type' shadowed in 'fun'"
warning when compiling with warnings turned on.  This is odd code anyway --
the fun(Type) ... end(Type) looks redundant to me.
